### PR TITLE
add hotkey to drain a server

### DIFF
--- a/KEYBINDS
+++ b/KEYBINDS
@@ -27,6 +27,9 @@ Hotkeys for common administrative actions
 ::
 
   Hotkey      Action
+  F1          Enable server on all backends (return from maintenance mode)
+  F2          Disable server on all backends (put into maintenance mode)
+  F3          Drain server on all backends (prepare for maintenance mode, don't allow new connections)
 
   F4          Restore initial server weight
 
@@ -35,8 +38,9 @@ Hotkeys for common administrative actions
   F7          Increase server weight:     +  1
   F8          Increase server weight:     + 10
 
-  F9          Enable server (return from maintenance mode)
-  F10         Disable server (put into maintenance mode)
+  F9          Enable server on one backend (return from maintenance mode)
+  F10         Disable server on one backend (put into maintenance mode)
+  F11         Drain server on one backend (prepare for maintenance mode, don't allow new connections)
 
 Hotkey actions and server responses are logged on the CLI viewport.
 

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,9 @@ Hotkeys for common administrative actions
 ::
 
   Hotkey      Action
+  F1          Enable server on all backends (return from maintenance mode)
+  F2          Disable server on all backends (put into maintenance mode)
+  F3          Drain server on all backends (prepare for maintenance mode, don't allow new connections)
 
   F4          Restore initial server weight
 
@@ -131,8 +134,9 @@ Hotkeys for common administrative actions
   F7          Increase server weight:     +  1
   F8          Increase server weight:     + 10
 
-  F9          Enable server (return from maintenance mode)
-  F10         Disable server (put into maintenance mode)
+  F9          Enable server on one backend (return from maintenance mode)
+  F10         Disable server on one backend (put into maintenance mode)
+  F11         Drain server on one backend (prepare for maintenance mode, don't allow new connections)
 
 Hotkey actions and server responses are logged on the CLI viewport.
 

--- a/bin/hatop
+++ b/bin/hatop
@@ -1867,7 +1867,7 @@ def mainloop(screen, interval):
             if c not in (
                     curses.KEY_F1,          # enable server on all backends
                     curses.KEY_F2,          # disable server on all backends
-                    curses.KEY_F3,          # drain server on all backend
+                    curses.KEY_F3,          # drain server on all backends
                     curses.KEY_F4,          # reset weight
                     curses.KEY_F5,          # weight -10
                     curses.KEY_F6,          # weight -1

--- a/bin/hatop
+++ b/bin/hatop
@@ -59,6 +59,7 @@ Hotkey      Action
 
 F1          Enable server on all backends (return from maintenance mode)
 F2          Disable server on all backends (put into maintenance mode)
+F3          Drain server on all backends (prepare for maintenance mode, don't allow new connections)
 
 F4          Restore initial server weight
 
@@ -69,6 +70,7 @@ F8          Increase server weight:     + 10
 
 F9          Enable server on one backend (return from maintenance mode)
 F10         Disable server on one backend (put into maintenance mode)
+F11         Drain server on one backend (prepare for maintenance mode, don't allow new connections)
 
 Hotkey actions and server responses are logged on the CLI viewport.
 You can scroll the output on the CLI view using PGUP / PGDOWN.
@@ -157,7 +159,7 @@ L7STS       layer 7 response error, for example HTTP 5xx
 __author__    = 'John Feuerstein <john@feurix.com>'
 __copyright__ = 'Copyright (C) 2011 %s' % __author__
 __license__   = 'GNU GPLv3'
-__version__   = '0.8.2'
+__version__   = '0.8.3'
 
 import fcntl
 import os
@@ -1166,10 +1168,10 @@ class Screen:
                 self.addstr(ypos, 1, 'HOTKEYS:',
                         curses.A_BOLD | curses.A_REVERSE)
                 self.addstr(ypos, 11,
-                        'F1=ENABLE  F2=DISABLE  '
+                        'F1=ENABLE  F2=DISABLE  F3=DRAIN  '
                         'F4=W-RESET  '
                         'F5=W-10  F6=W-1  F7=W+1  F8=W+10  '
-                        'F9=ENABLE (HERE)  F10=DISABLE (HERE)',
+                        'F9=ENABLE (HERE)  F10=DISABLE (HERE)  F11=DRAIN (HERE)',
                         curses.A_NORMAL | curses.A_REVERSE)
                 return
 
@@ -1865,6 +1867,7 @@ def mainloop(screen, interval):
             if c not in (
                     curses.KEY_F1,          # enable server on all backends
                     curses.KEY_F2,          # disable server on all backends
+                    curses.KEY_F3,          # drain server on all backend
                     curses.KEY_F4,          # reset weight
                     curses.KEY_F5,          # weight -10
                     curses.KEY_F6,          # weight -1
@@ -1872,6 +1875,7 @@ def mainloop(screen, interval):
                     curses.KEY_F8,          # weight +10
                     curses.KEY_F9,          # enable server on one backend
                     curses.KEY_F10,         # disable server on one backend
+                    curses.KEY_F11,         # drain server on one backend
             ):
                 screen.hotkeys = False
                 update_display = True
@@ -1967,6 +1971,7 @@ def mainloop(screen, interval):
                     chr(curses.ascii.SP),   # copy & paste identifier
                     curses.KEY_F1,          # enable server on all backends
                     curses.KEY_F2,          # disable server on all backends
+                    curses.KEY_F3,          # drain server on all backends
                     curses.KEY_F4,          # reset weight
                     curses.KEY_F5,          # weight -10
                     curses.KEY_F6,          # weight -1
@@ -1974,6 +1979,7 @@ def mainloop(screen, interval):
                     curses.KEY_F8,          # weight +10
                     curses.KEY_F9,          # enable server on one backend
                     curses.KEY_F10,         # disable server on one backend
+                    curses.KEY_F11,         # drain server on one backend
             ):
                 if screen.data.socket.ro:
                     continue
@@ -2021,6 +2027,19 @@ def mainloop(screen, interval):
                                     screen.cli.execute_cmdline(
                                             '%s %s/%s' % (cliname, sv['pxname'], svname))
                                     notify = True
+                elif c == curses.KEY_F3:
+                    # loop on all proxies (backends)
+                    for px in screen.data.stat.values():
+                        # in a given proxy, loop on all services id (unique inside a proxy)
+                        # a service can be a frontend, backend, server or socket object
+                        for sv in px.values():
+                            if sv['type'] == 2: # only the type "server" interests us
+                                # selects only the service name (hostname)
+                                # which matches that of the current line
+                                if sv['svname'] == svname:
+                                    screen.cli.execute_cmdline(
+                                            'set server %s/%s state drain' % (pxname, svname))
+                                    notify = True
                 elif c == curses.KEY_F4:
                     screen.cli.execute_cmdline(
                             'set weight %s/%s 100%%' % (pxname, svname))
@@ -2064,6 +2083,10 @@ def mainloop(screen, interval):
                 elif c == curses.KEY_F10:
                     screen.cli.execute_cmdline(
                             'disable server %s/%s' % (pxname, svname))
+                    notify = True
+                elif c == curses.KEY_F11:
+                    screen.cli.execute_cmdline(
+                            'set server %s/%s state drain' % (pxname, svname))
                     notify = True
 
                 # Refresh the screen indicating pending changes...

--- a/man/hatop.1
+++ b/man/hatop.1
@@ -76,6 +76,15 @@ Copy and paste selected service identifier to the CLI
 Scroll the stat views to select a given service
 .SH HOTKEYS
 .TP
+\fBF1\fP
+Enable server on all backends (return from maintenance mode)
+.TP
+\fBF2\fP
+Disable server on all backends (put into maintenance mode)
+.TP
+\fBF3\fP
+Drain server on all backends (prepare for maintenance mode, don't allow new connections)
+.TP
 \fBF4\fP
 Restore initial server weight
 
@@ -94,10 +103,13 @@ Increase server weight:     + 10
 
 .TP
 \fBF9\fP
-Enable server (return from maintenance mode)
+Enable server on one backend (return from maintenance mode)
 .TP
 \fBF10\fP
-Disable server (put into maintenance mode)
+Disable server on one backend (put into maintenance mode)
+.TP
+\fBF11\fP
+Drain server on one backend (prepare for maintenance mode, don't allow new connections)
 .SH SEE ALSO
 .BR haproxy (1)
 


### PR DESCRIPTION
The drain-mode keep all existing connections to complete, but not allow new connections. It's good to prepare a server for maintenance without kill all current connections to the backend server. The hotkey (F3) drain the server on all backends and the hotkey (F11) drain only the current server.